### PR TITLE
Minor: Upgrade to .NET 4.5.2 since 4.5.1 unsupported as of 1/12/2016.

### DIFF
--- a/iddd_agilepm/AgilePM.csproj
+++ b/iddd_agilepm/AgilePM.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SaaSOvation.AgilePM</RootNamespace>
     <AssemblyName>SaaSOvation.AgilePM</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>8432808d</NuGetPackageImportStamp>

--- a/iddd_collaboration/Collaboration.csproj
+++ b/iddd_collaboration/Collaboration.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SaaSOvation.Collaboration</RootNamespace>
     <AssemblyName>SaaSOvation.Collaboration</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>4c5a0288</NuGetPackageImportStamp>

--- a/iddd_common/Common.csproj
+++ b/iddd_common/Common.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SaaSOvation.Common</RootNamespace>
     <AssemblyName>SaaSOvation.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>e360a1eb</NuGetPackageImportStamp>

--- a/iddd_identityaccess/IdentityAccess.csproj
+++ b/iddd_identityaccess/IdentityAccess.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SaaSOvation.IdentityAccess</RootNamespace>
     <AssemblyName>SaaSOvation.IdentityAccess</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>888a5d24</NuGetPackageImportStamp>


### PR DESCRIPTION
Hopefully more in the .NET community will use this IDDD Sample.  As they do, I hope they'll avoid unsupported .NET 4, 4.5 and 4.5.1.